### PR TITLE
Compile with ASLR flags

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -36,6 +36,9 @@ project "msdf-atlas-gen"
 	filter "system:windows"
 		systemversion "latest"
 
+	filter "system:Linux"
+		buildoptions { "-fPIE" }
+
 	filter "configurations:Debug"
 		runtime "Debug"
 		symbols "on"


### PR DESCRIPTION
Adds -fPIE flag to enable address space layout randomization on Linux gcc compilers